### PR TITLE
chore: drop dead legacy /v1/context client method

### DIFF
--- a/internal/commands/conversation_enriched_memory_test.go
+++ b/internal/commands/conversation_enriched_memory_test.go
@@ -65,7 +65,6 @@ func TestMentionConversationContinuesWithoutLegacyContextWhenCombinedContextFail
 	assistant := &fakeAssistantClient{reply: "I'm PC, Texas A&M!"}
 	memoryClient := &fakeMemoryClient{
 		memoryContextErr: errors.New("combined memory unavailable"),
-		contextText:      "legacy short-term continuity",
 		graphText:        "legacy graph fact",
 	}
 	previousAssistant := assistantClient
@@ -85,8 +84,8 @@ func TestMentionConversationContinuesWithoutLegacyContextWhenCombinedContextFail
 	if err != nil {
 		t.Fatalf("expected conversation to continue without legacy fallback, got %v", err)
 	}
-	if len(memoryClient.memoryContextCalls) != 1 || len(memoryClient.queries) != 0 || len(memoryClient.graphCalls) != 0 {
-		t.Fatalf("expected only combined gnosis memory query, got combined=%d legacy=%d graph=%d", len(memoryClient.memoryContextCalls), len(memoryClient.queries), len(memoryClient.graphCalls))
+	if len(memoryClient.memoryContextCalls) != 1 || len(memoryClient.graphCalls) != 0 {
+		t.Fatalf("expected only combined gnosis memory query, got combined=%d graph=%d", len(memoryClient.memoryContextCalls), len(memoryClient.graphCalls))
 	}
 	joinedPrompt := assistantPromptText(assistant.messages)
 	for _, blocked := range []string{"legacy short-term continuity", "legacy graph fact", "Relevant reviewed memory context:"} {

--- a/internal/commands/conversation_graph_context_test.go
+++ b/internal/commands/conversation_graph_context_test.go
@@ -92,8 +92,8 @@ func TestMentionConversationDoesNotDuplicateGraphAndLongTermSections(t *testing.
 	if strings.Count(joinedPrompt, "Long-term recall: blackflame likes homelab memory") != 1 || strings.Count(joinedPrompt, "Graph fact: #general discussed Dragonfly yesterday") != 1 {
 		t.Fatalf("expected graph and long-term content exactly once, got %#v", assistant.messages)
 	}
-	if len(memoryClient.queries) != 0 || len(memoryClient.graphCalls) != 0 {
-		t.Fatalf("expected no legacy calls after combined memory success, got queries=%d graph=%d", len(memoryClient.queries), len(memoryClient.graphCalls))
+	if len(memoryClient.graphCalls) != 0 {
+		t.Fatalf("expected no legacy graph calls after combined memory success, got graph=%d", len(memoryClient.graphCalls))
 	}
 }
 

--- a/internal/commands/conversation_memory_test.go
+++ b/internal/commands/conversation_memory_test.go
@@ -80,8 +80,8 @@ func TestMentionConversationIncludesCombinedMemoryContextOnce(t *testing.T) {
 	if len(memoryClient.memoryContextCalls) != 1 {
 		t.Fatalf("expected one combined memory call, got %d", len(memoryClient.memoryContextCalls))
 	}
-	if len(memoryClient.queries) != 0 || len(memoryClient.graphCalls) != 0 {
-		t.Fatalf("expected no legacy context calls after combined memory success, got queries=%d graph=%d", len(memoryClient.queries), len(memoryClient.graphCalls))
+	if len(memoryClient.graphCalls) != 0 {
+		t.Fatalf("expected no legacy graph calls after combined memory success, got graph=%d", len(memoryClient.graphCalls))
 	}
 	joinedPrompt := assistantPromptText(assistant.messages)
 	for _, want := range []string{"Relevant reviewed memory context:", "Source: short_term", "recent channel context", "Source: long_term_facts", "blackflame prefers graph memory", "kind=preference", "summary=use combined context", "Reviewed non-executable skills:", "Review memory"} {
@@ -132,7 +132,7 @@ func TestMentionConversation_writes_user_and_assistant_messages_to_memory(t *tes
 func TestMentionConversation_ignores_memory_errors(t *testing.T) {
 	// Given
 	assistant := &fakeAssistantClient{reply: "I'm PC, Texas A&M!"}
-	memoryClient := &fakeMemoryClient{memoryContextErr: errors.New("combined memory unavailable"), contextErr: errors.New("memory unavailable"), writeErr: errors.New("write failed")}
+	memoryClient := &fakeMemoryClient{memoryContextErr: errors.New("combined memory unavailable"), writeErr: errors.New("write failed")}
 	previousAssistant := assistantClient
 	assistantClient = assistant
 	t.Cleanup(func() { assistantClient = previousAssistant })

--- a/internal/commands/conversation_reasoning_test.go
+++ b/internal/commands/conversation_reasoning_test.go
@@ -91,7 +91,6 @@ func TestMentionConversationRecordsMemoryContextFailureWithoutLegacyFallback(t *
 	assistant := &fakeAssistantClient{reply: "I'm PC, Texas A&M!"}
 	memoryClient := &fakeMemoryClient{
 		memoryContextErr: errors.New("combined context offline detail"),
-		contextText:      "legacy memory context",
 		graphText:        "legacy graph context",
 	}
 	previousAssistant := assistantClient
@@ -111,8 +110,8 @@ func TestMentionConversationRecordsMemoryContextFailureWithoutLegacyFallback(t *
 	if err != nil {
 		t.Fatalf("expected conversation to continue without memory context, got %v", err)
 	}
-	if len(memoryClient.queries) != 0 || len(memoryClient.graphCalls) != 0 {
-		t.Fatalf("expected no legacy memory fallback, got queries=%d graph=%d", len(memoryClient.queries), len(memoryClient.graphCalls))
+	if len(memoryClient.graphCalls) != 0 {
+		t.Fatalf("expected no legacy graph fallback, got graph=%d", len(memoryClient.graphCalls))
 	}
 	if hasReasoningToolCall(memoryClient.toolCalls, "gnosis.memory_context", "success") {
 		t.Fatalf("expected memory context failure not to be recorded as success, got %#v", memoryClient.toolCalls)

--- a/internal/commands/conversation_test_fakes_test.go
+++ b/internal/commands/conversation_test_fakes_test.go
@@ -19,8 +19,6 @@ func (c *fakeAssistantClient) Generate(ctx context.Context, messages []store.Mes
 }
 
 type fakeMemoryClient struct {
-	contextText        string
-	contextErr         error
 	graphText          string
 	graphErr           error
 	memoryContext      memory.MemoryContextResponse
@@ -28,7 +26,6 @@ type fakeMemoryClient struct {
 	skills             []memory.SkillRecord
 	skillsErr          error
 	writeErr           error
-	queries            []memory.ContextQuery
 	graphCalls         []memory.GraphContextRequest
 	memoryContextCalls []memory.MemoryContextRequest
 	skillCalls         []memory.SkillListRequest
@@ -41,11 +38,6 @@ type fakeMemoryClient struct {
 	reasoningSteps     []memory.ReasoningStepRequest
 	toolCalls          []memory.ReasoningToolCallRequest
 	completedTraces    []memory.ReasoningTraceCompleteRequest
-}
-
-func (c *fakeMemoryClient) GetContext(ctx context.Context, query memory.ContextQuery) (string, error) {
-	c.queries = append(c.queries, query)
-	return c.contextText, c.contextErr
 }
 
 func (c *fakeMemoryClient) AddMessage(ctx context.Context, message memory.Message) error {

--- a/internal/memory/client.go
+++ b/internal/memory/client.go
@@ -32,12 +32,6 @@ type Config struct {
 	TenantID string
 }
 
-type ContextQuery struct {
-	Scope Scope
-	Query string
-	Limit int
-}
-
 type Message struct {
 	Scope   Scope
 	Role    Role
@@ -45,7 +39,6 @@ type Message struct {
 }
 
 type Client interface {
-	GetContext(ctx context.Context, query ContextQuery) (string, error)
 	AddMessage(ctx context.Context, message Message) error
 	IngestEvent(ctx context.Context, event ClientEvent) error
 	IngestEvents(ctx context.Context, events []ClientEvent) (ClientEventBatchResponse, error)
@@ -66,16 +59,6 @@ type HTTPClient struct {
 	baseURL    string
 	token      string
 	enabled    bool
-}
-
-type contextRequest struct {
-	Scope Scope  `json:"scope"`
-	Query string `json:"query"`
-	Limit int    `json:"limit"`
-}
-
-type contextResponse struct {
-	Context string `json:"context"`
 }
 
 type messageWriteRequest struct {
@@ -107,26 +90,6 @@ func NewClient(config Config, httpClient *http.Client) *HTTPClient {
 		token:      config.Token,
 		enabled:    config.Enabled && config.BaseURL != "" && config.Token != "",
 	}
-}
-
-func (c *HTTPClient) GetContext(ctx context.Context, query ContextQuery) (string, error) {
-	if !c.enabled {
-		return "", nil
-	}
-	request := contextRequest{Scope: query.Scope, Query: query.Query, Limit: query.Limit}
-	requestBytes, err := json.Marshal(request)
-	if err != nil {
-		return "", fmt.Errorf("encode context request: %w", err)
-	}
-	responseBytes, err := c.post(ctx, "/v1/context", requestBytes)
-	if err != nil {
-		return "", fmt.Errorf("get memory context: %w", err)
-	}
-	var response contextResponse
-	if err := json.Unmarshal(responseBytes, &response); err != nil {
-		return "", fmt.Errorf("decode context response: %w", err)
-	}
-	return response.Context, nil
 }
 
 func (c *HTTPClient) AddMessage(ctx context.Context, message Message) error {

--- a/internal/memory/client_test.go
+++ b/internal/memory/client_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 )
 
@@ -22,47 +21,6 @@ func TestLoadConfigFromEnv_readsGnosisEnv(t *testing.T) {
 	// Then
 	if !config.Enabled || config.BaseURL != "http://gnosis.local" || config.Token != "gnosis-token" || config.TenantID != "tenant-1" {
 		t.Fatalf("expected gnosis env config, got %#v", config)
-	}
-}
-
-func TestClient_GetContext_sendsScopedAuthorizedRequest(t *testing.T) {
-	// Given
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/v1/context" {
-			t.Fatalf("expected POST /v1/context, got %s %s", r.Method, r.URL.Path)
-		}
-		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
-			t.Fatalf("expected bearer token, got %q", got)
-		}
-		var body contextRequest
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode context request: %v", err)
-		}
-		if body.Query != "what does blackflame like?" || body.Limit != 6 {
-			t.Fatalf("expected query and limit to pass through, got %#v", body)
-		}
-		if body.Scope.AgentID != "pc-principal" || body.Scope.Visibility != VisibilityChannel {
-			t.Fatalf("expected PC Principal channel scope, got %#v", body.Scope)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"context":"blackflame likes homelab memory"}`))
-	}))
-	t.Cleanup(server.Close)
-	client := NewClient(Config{Enabled: true, BaseURL: server.URL, Token: "test-token"}, server.Client())
-
-	// When
-	got, err := client.GetContext(context.Background(), ContextQuery{
-		Scope: testScope(),
-		Query: "what does blackflame like?",
-		Limit: 6,
-	})
-
-	// Then
-	if err != nil {
-		t.Fatalf("expected context request to succeed, got %v", err)
-	}
-	if got != "blackflame likes homelab memory" {
-		t.Fatalf("expected recalled context, got %q", got)
 	}
 }
 
@@ -156,11 +114,6 @@ func TestClient_Noops_whenDisabled(t *testing.T) {
 	client := NewClient(Config{Enabled: false, BaseURL: server.URL, Token: "test-token"}, server.Client())
 
 	// When
-	contextText, contextErr := client.GetContext(context.Background(), ContextQuery{
-		Scope: testScope(),
-		Query: "query",
-		Limit: 4,
-	})
 	messageErr := client.AddMessage(context.Background(), Message{
 		Scope:   testScope(),
 		Role:    RoleUser,
@@ -179,11 +132,11 @@ func TestClient_Noops_whenDisabled(t *testing.T) {
 	usageErr := client.RecordSkillUsage(context.Background(), testSkillUsage())
 
 	// Then
-	if contextErr != nil || messageErr != nil || ingestErr != nil || graphErr != nil || memoryErr != nil || traceErr != nil || stepErr != nil || toolErr != nil || completeErr != nil || reasoningErr != nil || skillsErr != nil || proposalErr != nil || usageErr != nil {
-		t.Fatalf("expected disabled client to no-op, got contextErr=%v messageErr=%v ingestErr=%v graphErr=%v memoryErr=%v traceErr=%v stepErr=%v toolErr=%v completeErr=%v reasoningErr=%v skillsErr=%v proposalErr=%v usageErr=%v", contextErr, messageErr, ingestErr, graphErr, memoryErr, traceErr, stepErr, toolErr, completeErr, reasoningErr, skillsErr, proposalErr, usageErr)
+	if messageErr != nil || ingestErr != nil || graphErr != nil || memoryErr != nil || traceErr != nil || stepErr != nil || toolErr != nil || completeErr != nil || reasoningErr != nil || skillsErr != nil || proposalErr != nil || usageErr != nil {
+		t.Fatalf("expected disabled client to no-op, got messageErr=%v ingestErr=%v graphErr=%v memoryErr=%v traceErr=%v stepErr=%v toolErr=%v completeErr=%v reasoningErr=%v skillsErr=%v proposalErr=%v usageErr=%v", messageErr, ingestErr, graphErr, memoryErr, traceErr, stepErr, toolErr, completeErr, reasoningErr, skillsErr, proposalErr, usageErr)
 	}
-	if contextText != "" || len(ingestResponse.Results) != 0 || graphResponse.Context != "" || len(memoryResponse.Sections) != 0 || traceResponse.TraceID != "" || stepResponse.StepID != "" || toolResponse.ToolCallID != "" || completeResponse.TraceID != "" || reasoningResponse.Context != "" || len(skillsResponse.Skills) != 0 || proposalResponse.ProposalID != "" {
-		t.Fatalf("expected disabled empty responses, got context=%q ingest=%#v graph=%#v memory=%#v trace=%#v step=%#v tool=%#v complete=%#v reasoning=%#v skills=%#v proposal=%#v", contextText, ingestResponse, graphResponse, memoryResponse, traceResponse, stepResponse, toolResponse, completeResponse, reasoningResponse, skillsResponse, proposalResponse)
+	if len(ingestResponse.Results) != 0 || graphResponse.Context != "" || len(memoryResponse.Sections) != 0 || traceResponse.TraceID != "" || stepResponse.StepID != "" || toolResponse.ToolCallID != "" || completeResponse.TraceID != "" || reasoningResponse.Context != "" || len(skillsResponse.Skills) != 0 || proposalResponse.ProposalID != "" {
+		t.Fatalf("expected disabled empty responses, got ingest=%#v graph=%#v memory=%#v trace=%#v step=%#v tool=%#v complete=%#v reasoning=%#v skills=%#v proposal=%#v", ingestResponse, graphResponse, memoryResponse, traceResponse, stepResponse, toolResponse, completeResponse, reasoningResponse, skillsResponse, proposalResponse)
 	}
 }
 
@@ -196,11 +149,6 @@ func TestClient_Noops_whenTokenMissing(t *testing.T) {
 	client := NewClient(Config{Enabled: true, BaseURL: server.URL}, server.Client())
 
 	// When
-	contextText, contextErr := client.GetContext(context.Background(), ContextQuery{
-		Scope: testScope(),
-		Query: "query",
-		Limit: 4,
-	})
 	messageErr := client.AddMessage(context.Background(), Message{
 		Scope:   testScope(),
 		Role:    RoleUser,
@@ -208,39 +156,8 @@ func TestClient_Noops_whenTokenMissing(t *testing.T) {
 	})
 
 	// Then
-	if contextErr != nil || messageErr != nil {
-		t.Fatalf("expected missing token client to no-op, got contextErr=%v messageErr=%v", contextErr, messageErr)
-	}
-	if contextText != "" {
-		t.Fatalf("expected missing token context to be empty, got %q", contextText)
-	}
-}
-
-func TestClient_GetContext_sanitizesErrorResponseBody(t *testing.T) {
-	// Given
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"detail":"secret token scope details"}`))
-	}))
-	t.Cleanup(server.Close)
-	client := NewClient(Config{Enabled: true, BaseURL: server.URL, Token: "test-token"}, server.Client())
-
-	// When
-	_, err := client.GetContext(context.Background(), ContextQuery{
-		Scope: testScope(),
-		Query: "query",
-		Limit: 4,
-	})
-
-	// Then
-	if err == nil {
-		t.Fatal("expected context request to fail")
-	}
-	if strings.Contains(err.Error(), "secret token scope details") {
-		t.Fatalf("expected sanitized error, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "gnosis returned 403") {
-		t.Fatalf("expected status code in error, got %v", err)
+	if messageErr != nil {
+		t.Fatalf("expected missing token client to no-op, got messageErr=%v", messageErr)
 	}
 }
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -19,10 +19,6 @@ type fakeLiveMemoryClient struct {
 	batches   [][]memory.ClientEvent
 }
 
-func (c *fakeLiveMemoryClient) GetContext(ctx context.Context, query memory.ContextQuery) (string, error) {
-	return "", nil
-}
-
 func (c *fakeLiveMemoryClient) AddMessage(ctx context.Context, message memory.Message) error {
 	return nil
 }


### PR DESCRIPTION
GetContext had zero non-test callers (production uses GetMemoryContext). Removes the interface method, HTTP implementation, request/response types, fakes, and dedicated tests. Net −134 lines. `go build ./... && go vet ./... && go test ./...` green.

Pairs with bromigos-org/gnosis#4, which deprecates the server route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)