### PR TITLE
docs: drop phantom env vars, fix rollout flag, real SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,19 +141,13 @@ These should come from Vault or another secret manager. Helm values can wire URL
 - `LITELLM_API_KEY`
 - `DRAGONFLY_ADDR`
 - `GNOSIS_ENABLED`
-- `GNOSIS_EVENTS_ENABLED`
-- `GNOSIS_GRAPH_CONTEXT_ENABLED`
 - `GNOSIS_SERVICE_URL`
 - `GNOSIS_SERVICE_TOKEN`
 - `GNOSIS_TENANT_ID`
 - `DISCORD_HISTORY_BACKFILL_ENABLED`
 - `DISCORD_HISTORY_BACKFILL_GNOSIS_BATCH_SIZE`
-- `DISCORD_BACKFILL_ENABLED`
 - `DISCORD_AMBIENT_REPLIES_ENABLED`
-- `AMBIENT_REPLIES_ENABLED`
-- `DISCORD_ATTACHMENT_METADATA_ENABLED`
 - `DISCORD_ATTACHMENT_COPY_ENABLED`
-- `DISCORD_ATTACHMENT_COPY_POLICY`
 
 ## Local development
 
@@ -189,7 +183,7 @@ PC-Principal is expected to run in Kubernetes with GitOps-driven config changes.
 
 1. Land the code or Helm change in Git.
 2. Let ArgoCD reconcile the `pc-principal` chart.
-3. Enable `GNOSIS_ENABLED`, `GNOSIS_EVENTS_ENABLED`, and related flags only when the matching `gnosis` behavior is ready.
+3. Enable `GNOSIS_ENABLED` and related flags only when the matching `gnosis` behavior is ready.
 4. Keep backfill, ambient replies, and attachment copying off unless the rollout needs them.
 5. Verify command handling, mention conversation flow, and one memory-backed request path.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,17 @@
 # Security Policy
 
-## Supported Versions
+## Reporting a vulnerability
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Please report suspected security issues **privately** to
+**contact@bromigos.org**. Do not open a public GitHub issue for a suspected
+vulnerability.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+Include enough detail to reproduce it — the affected version or commit, the
+environment, and the steps involved. We aim to acknowledge reports within a few
+business days and will keep you informed as we investigate and ship a fix.
 
-## Reporting a Vulnerability
+## Supported versions
 
-Use this section to tell people how to report a vulnerability.
-
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+PC-Principal is pre-1.0 and ships continuously from `main`; security fixes land
+on `main` and in the current container image. There is no back-port branch — run
+the latest image to stay current.


### PR DESCRIPTION
Staleness pass on the README + SECURITY.md.

## Phantom env vars removed
The "Key environment variables" list documented **six vars read nowhere in the code** (each greps only to the README):

| Removed | Reality |
|---|---|
| `GNOSIS_EVENTS_ENABLED` | no such flag — events follow `GNOSIS_ENABLED` (`IngestEvents` called unconditionally when the client is up) |
| `GNOSIS_GRAPH_CONTEXT_ENABLED` | graph inclusion is hardcoded `IncludeGraph: true` |
| `DISCORD_BACKFILL_ENABLED` | phantom dup of `DISCORD_HISTORY_BACKFILL_ENABLED` |
| `AMBIENT_REPLIES_ENABLED` | phantom dup of `DISCORD_AMBIENT_REPLIES_ENABLED` |
| `DISCORD_ATTACHMENT_METADATA_ENABLED` | metadata-first is default; no toggle |
| `DISCORD_ATTACHMENT_COPY_POLICY` | no such var (real: `DISCORD_ATTACHMENT_COPY_{BUCKET,MAX_SIZE_BYTES,CONTENT_TYPES,TIMEOUT}`) |

Also removed the same phantom `GNOSIS_EVENTS_ENABLED` from Rollout step 3.

## SECURITY.md
Was still the **unedited GitHub default template** (placeholder prose + a bogus `5.1.x`/`5.0.x`/`4.0.x` supported-versions table). Replaced with a real policy pointing to `contact@bromigos.org` (already the CoC contact).

Docs only — no Go code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)